### PR TITLE
refactor(server): gradually replace github's rest api usages with graphql

### DIFF
--- a/server/src/auth/service.ts
+++ b/server/src/auth/service.ts
@@ -1,25 +1,22 @@
 import {
   getAccessToken,
   getAuthorizationUrl as getAuthUrl,
-  getUserProfile,
+  getAuthorizedUser,
   logger,
 } from '../infrastructure';
 import { createUser } from '../user';
 
-// let's start with the empty scope
-const scopes: string[] = [];
-
 export function getAuthorizationUrl(): string {
-  return getAuthUrl(scopes);
+  return getAuthUrl();
 }
 
 export async function signInOrSignUp(code: string): Promise<string> {
   const { token, scope } = await getAccessToken(code);
-  const profile = await getUserProfile(token);
+  const profile = await getAuthorizedUser(token);
 
   const acceptedScopes = scope.split(',');
   const user = await createUser({
-    name: profile.name,
+    name: profile.login,
     email: profile.email,
     avatarUrl: profile.avatarUrl,
     accessToken: token,

--- a/server/src/infrastructure/github/queries.ts
+++ b/server/src/infrastructure/github/queries.ts
@@ -3,8 +3,8 @@
 // /* GraphQL */ comment tags are supported.
 import gql from 'fake-tag';
 
-export const queryUserWithRepository = gql`
-  query UserWithRepository($repoOwner: String!) {
+export const getUserWithRepositoryQuery = gql`
+  query GetUserWithRepository($repoOwner: String!) {
     user(login: $repoOwner) {
       id
       name
@@ -14,6 +14,16 @@ export const queryUserWithRepository = gql`
         id
         name
       }
+    }
+  }
+`;
+
+export const getAuthorizedUserQuery = gql`
+  query GetAuthorizedUser {
+    viewer {
+      login
+      email
+      avatarUrl
     }
   }
 `;

--- a/server/src/infrastructure/github/types.ts
+++ b/server/src/infrastructure/github/types.ts
@@ -6,11 +6,7 @@ export interface AccessToken {
   scope: string;
 }
 
-export interface UserProfile {
-  name: string;
-  email: string;
-  avatarUrl: string;
-}
+export type AuthorizedUser = Pick<User, 'login' | 'email' | 'avatarUrl'>;
 
 export interface RepositoryWithOwner {
   repository: Pick<Repository, 'id' | 'name'> | null;


### PR DESCRIPTION
- Updated authorized user profile access from rest-api to graphql
- Added `read:user` scope to the auth flow
- Since the authorized user's `name` field is optional in Github,
  the `login` field is used as a name when creating the user.